### PR TITLE
Docker_build.sh updated with strict mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+.java
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,7 +2,7 @@
 # Gradle build in Docker with persistent Gradle cache.
 #
 # author: Weleoka <weleoka@mailfence.com>
-# edited: 2020-11-07
+# edited: 2020-11-08
 #
 # Creates a persistent gradle cache for the build container here in the project /build dir.
 # Because Gradle is "installed" for a normal user in the official Gradle docker images we have to work around that.
@@ -15,32 +15,31 @@
 # - tried to mount the modules-2 folder as a volume but that made the parent dir owned by root,
 #     so sister files to modules-2 could not be created
 #
+set -euo pipefail
 script="`realpath "$0"`"
 project_dir="`dirname "$script"`"
 docker_gradle_image="gradle:6.7.0-jdk11"
 # gradle:6.7.0-jdk11 is gradle@sha256:33f85a6c2d3fd5f81987f66db3a3e379e562587e20b5ae404d8c4f7f62f37fb3
 
 echo
-echo "== Building Gradle project: ${project_dir} with docker image: ${docker_gradle_image}"
+echo "== Building Gradle project: ${project_dir} in Docker container (${docker_gradle_image})."
 
-echo "Create Gradle build cache dir on host for mounting to container."
+echo "> Create persistent build cache directory."
 mkdir -p "$project_dir"/build/docker_build_cache
-echo
 
 
 # Note added this as removing classes in source code was not reflected
 # in the extracted archive contents after build. Due to class autoloading
 # old classes appear again and again.
-echo "Removing build/application and build/classes folder and ensure clean build."
-echo "DISABLED as we do not use multilayer Jars yet."
+echo "> (disabled) Removing build/application and build/classes folder to ensure clean build."
+# This is disabled as we do not use multilayer Jars yet."
 #rm -r "${project_dir}/build/application"
 #rm -r "${project_dir}/build/classes"
-echo
 
 
-echo "== Running gradle bootJar and more commands in gradle build container."
+echo "> Start the build process..."
 # Choose here if you want to do manual bash commands or the provided ones.
-docker run -it --name gradle_builder --rm -u gradle \
+docker run --name gradle_builder --rm -u gradle \
 -v "$project_dir":/home/gradle \
 -v "$project_dir"/build/docker_build_cache:/home/gradle/.gradle/caches \
 -w /home/gradle \
@@ -57,12 +56,11 @@ docker run -it --name gradle_builder --rm -u gradle \
 # todo: Q: what's the --build-cache flag for gradle?
 # todo: Q: the --no-daemon flag for gradle? Might be important for parallel running,
 #   as per: https://dev.to/markomannux/gradle-daemon-with-multi-module-spring-project-3nog
-echo "Build process complete."
-echo
 
-echo "Remove the *.lock for gradle_build_cache/ for next time running"
+
+echo "> Remove *.lock in Gradle persistent cache for next time running."
 rm -r "$project_dir"/build/docker_build_cache/modules-2/*.lock
-echo
 
-echo "== Finished building Gradle project in Docker container."
+
+echo "> Done!"
 echo


### PR DESCRIPTION
The script now uses strict mode which will return 1 on any failing command.

We've also dropped the -it flags on docker run command, as well as just
going over and cleaning things up in terms of feedback to user.